### PR TITLE
Fixed problem with missing a message of the error

### DIFF
--- a/chrome/content/consoleexport/consoleListener.js
+++ b/chrome/content/consoleexport/consoleListener.js
@@ -51,10 +51,16 @@ Firebug.ConsoleExport.Listener =
 
         try
         {
+            var message = null;
+            if (typeof object == "string") {
+                message = JSON.stringify(object);
+            } else {
+                message = object.message;
+            }
             Firebug.ConsoleExport.Uploader.send({
                 className: className,
                 cat: object.category,
-                msg: object.message,
+                msg: message,
                 href: object.href ? object.href : context.getName(),
                 lineNo: object.lineNo,
                 source: object.source,


### PR DESCRIPTION
Befor:
<log><class>error</class><href>http://www.example.com/test.html</href></log>

After:
<log><class>error</class><msg>"NetworkError: 404 Not Found - http://www.example.com/pokus.png"</msg><href>http://www.example.com/test.html</href></log>
