### PR TITLE
console log format enhancements

### DIFF
--- a/chrome/content/consoleexport/consoleDumper.js
+++ b/chrome/content/consoleexport/consoleDumper.js
@@ -5,149 +5,98 @@ FBL.ns(function() { with (FBL) {
 // ************************************************************************************************
 // Constants
 
-const Cc = Components.classes;
-const Ci = Components.interfaces;
+    const Cc = Components.classes;
+    const Ci = Components.interfaces;
 
-var prefDomain = "extensions.firebug.consoleexport";
+    var prefDomain = "extensions.firebug.consoleexport";
 
 // ************************************************************************************************
 // Module implementation
 
-/**
- * This object implements dumping messages to a file
- * This object is also responsible for building XML messages.
- */
-Firebug.ConsoleExport.Dumper = extend(Firebug.Module,
-/** @lends Firebug.ConsoleExport.Dumper */
-{
-    initialize: function(){
-        
-        if (FBTrace.DBG_CONSOLEEXPORT)
-            FBTrace.sysout("initialize consoleexport.Dumper.dump");
-        this.dumps = [];
-        Firebug.Module.initialize.apply(this, arguments);
-
-    },
-    shutdown: function(){
-        
-        Firebug.Module.shutdown.apply(this, arguments);
-
-        
-        if (FBTrace.DBG_CONSOLEEXPORT)
-            FBTrace.sysout("shutdown consoleexport.Dumper.dump with dumps.length="+this.dumps.length);
-
-        var path = Firebug.getPref(prefDomain, "logFilePath");
-        if (!path){
-            return;
-        }
-
-        var content;
-        var format = Firebug.getPref(prefDomain, "format")
-        if (format != null && format.toLowerCase() == "json"){
-            content = JSON.stringify(this.dumps);
-        }
-        else{
-           content ="<logs>";
-            for(var i=0; i<this.dumps.length; i++){
-                content += this.buildPacket(this.dumps[i]);
-            }
-            content +="</logs>";
-        }
-        this.writeToFile({
-            path: path,
-            data: content
-        });
-    },
-    dump: function(data)
+    /**
+     * This object implements dumping messages to a file
+     * This object is also responsible for building XML messages.
+     */
+    Firebug.ConsoleExport.Dumper =
+    /** @lends Firebug.ConsoleExport.Dumper */
     {
-        this.dumps.push(data);
-    },
+        dump: function(data)
+        {
+            var format = Firebug.getPref(prefDomain, "format")
+            var content = null;
+            var contentType = "application/xml";
 
-    // TODO: c&p from consoleUploader, could be moved to some common util
-    buildPacket: function(data) {
-        var xml = "<log>";
-
-        if (data.className)
-            xml += "<class>" + data.className + "</class>";
-
-        if (data.cat)
-            xml += "<cat>" + data.cat + "</cat>";
-
-        if (data.msg)
-            xml += "<msg><![CDATA[" + data.msg + "]]></msg>";
-
-        if (data.href)
-            xml += "<href><![CDATA[" + data.href + "]]></href>";
-
-        if (data.lineNo)
-            xml += "<lineNo>" + data.lineNo + "</lineNo>";
-
-        if (data.source)
-            xml += "<source>" + data.source + "</source>";
-
-        if (data.time)
-            xml += "<time>" + this.dateToJSON(new Date(data.time)) + "</time>";
-
-        xml += "</log>";
-
-        return xml;
-    },
-
-    dateToJSON: function (date){
-        function f(n, c) {
-            if (!c) c = 2;
-            var s = new String(n);
-            while (s.length < c) s = "0" + s;
-            return s;
-        }
-
-        if(!(date instanceof Date)){
-            date = new Date(date);
-        }
-        var result = date.getFullYear() + '-' +
-            f(date.getMonth() + 1) + '-' +
-            f(date.getDate()) + 'T' +
-            f(date.getHours()) + ':' +
-            f(date.getMinutes()) + ':' +
-            f(date.getSeconds()) + '.' +
-            f(date.getMilliseconds(), 3);
-
-        var offset = date.getTimezoneOffset();
-        var positive = offset > 0;
-
-        // Convert to positive number before using Math.floor (see issue 5512)
-        offset = Math.abs(offset);
-        var offsetHours = Math.floor(offset / 60);
-        var offsetMinutes = Math.floor(offset % 60);
-        var prettyOffset = (positive > 0 ? "-" : "+") + f(offsetHours) + ":" + f(offsetMinutes);
-
-        return result + prettyOffset;
-    },
-
-    writeToFile: function(options) {
-        try {
-            var file = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsILocalFile);
-            file.initWithPath( options.path );
-            if(file.exists() == false) {
-                file.create( Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 420);
+            if (format != null && format.toLowerCase() == "json")
+            {
+                contentType = "application/json";
+                content = JSON.stringify(data)+",";
             }
-            var foStream = Components.classes["@mozilla.org/network/file-output-stream;1"].createInstance(Components.interfaces.nsIFileOutputStream);
-            foStream.init(file, 0x02 | 0x10, 0666, 0); // open in append mode
+            else {
+                content = this.buildPacket(data);
+            }
+            var path = Firebug.getPref(prefDomain, "logFilePath");
 
-            var converter = Components.classes["@mozilla.org/intl/converter-output-stream;1"].createInstance(Components.interfaces.nsIConverterOutputStream);
-            converter.init(foStream, "UTF-8", 0, 0);
-            converter.writeString( options.data );
-            converter.close();
-        }
-        catch (e) {
-            if (FBTrace.DBG_CONSOLEEXPORT || FBTrace.DBG_ERRORS)
-                FBTrace.sysout("consoleexport.writeToFile; EXCEPTION " + e, e);
-        }
-    }
-});
-// ************************************************************************************************
-// Registration
+            if (FBTrace.DBG_CONSOLEEXPORT)
+                FBTrace.sysout("consoleexport.Dumper.dump; to: " +
+                    (path ? path : "no file path specified"), path);
 
-Firebug.registerModule(Firebug.ConsoleExport.Dumper);
+            if (!path)
+                return;
+
+            this.writeToFile({
+                path: path,
+                data: content
+            });
+        },
+
+        // TODO: c&p from consoleUploader, could be moved to some common util
+        buildPacket: function(data) {
+            var xml = "<log>";
+
+            if (data.className)
+                xml += "<class>" + data.className + "</class>";
+
+            if (data.cat)
+                xml += "<cat>" + data.cat + "</cat>";
+
+            if (data.msg)
+                xml += "<msg>" + data.msg + "</msg>";
+
+            if (data.href)
+                xml += "<href>" + data.href + "</href>";
+
+            if (data.lineNo)
+                xml += "<lineNo>" + data.lineNo + "</lineNo>";
+
+            if (data.source)
+                xml += "<source>" + data.source + "</source>";
+
+            xml += "</log>";
+
+            return xml;
+        },
+
+        writeToFile: function(options) {
+            try {
+                var file = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsILocalFile);
+                file.initWithPath( options.path );
+                if(file.exists() == false) {
+                    file.create( Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 420);
+                }
+                var foStream = Components.classes["@mozilla.org/network/file-output-stream;1"].createInstance(Components.interfaces.nsIFileOutputStream);
+                foStream.init(file, 0x02 | 0x10, 0666, 0); // open in append mode
+
+                var converter = Components.classes["@mozilla.org/intl/converter-output-stream;1"].createInstance(Components.interfaces.nsIConverterOutputStream);
+                converter.init(foStream, "UTF-8", 0, 0);
+                converter.writeString( options.data );
+                converter.close();
+            }
+            catch (e) {
+                if (FBTrace.DBG_CONSOLEEXPORT || FBTrace.DBG_ERRORS)
+                    FBTrace.sysout("consoleexport.writeToFile; EXCEPTION " + e, e);
+            }
+        }
+    };
+
 // ************************************************************************************************
 }});

--- a/chrome/content/consoleexport/consoleExport.js
+++ b/chrome/content/consoleexport/consoleExport.js
@@ -5,235 +5,235 @@ FBL.ns(function() { with (FBL) {
 // ************************************************************************************************
 // Constants
 
-const Cc = Components.classes;
-const Ci = Components.interfaces;
+    const Cc = Components.classes;
+    const Ci = Components.interfaces;
 
-var prefDomain = "extensions.firebug.consoleexport";
+    var prefDomain = "extensions.firebug.consoleexport";
 
 // ************************************************************************************************
 // Module implementation
 
-/**
- * @module This object represents the main module of the extension. Among its responsibility
- * belongs UI internationalization, managing auto-export feature, basic registration within
- * Firebug framework and also a simple support for debugging.
- * All other objects in this extension are defined within this object (namespace).
- * 
- * The purpose of this extension is to catch Console logs and sent them to a server that can
- * be specified using extensions.firebug.consoleexport.serverURL preference.
- */
-Firebug.ConsoleExport = extend(Firebug.Module,
-/** @lends Firebug.ConsoleExport */
-{
     /**
-     * Called by Firebug when new browser window is opened with Firebug.
+     * @module This object represents the main module of the extension. Among its responsibility
+     * belongs UI internationalization, managing auto-export feature, basic registration within
+     * Firebug framework and also a simple support for debugging.
+     * All other objects in this extension are defined within this object (namespace).
+     *
+     * The purpose of this extension is to catch Console logs and sent them to a server that can
+     * be specified using extensions.firebug.consoleexport.serverURL preference.
      */
-    initialize: function()
-    {
-        Firebug.Module.initialize.apply(this, arguments);
-
-        if (Firebug.TraceModule)
-            Firebug.TraceModule.addListener(this.TraceListener);
-    },
-
-    /**
-     * Called by Firebug when a browser window with Firebug is closed.
-     */
-    shutdown: function()
-    {
-        Firebug.Module.shutdown.apply(this, arguments);
-
-        if (Firebug.TraceModule)
-            Firebug.TraceModule.removeListener(this.TraceListener);
-    },
-
-    /**
-     * Called by Firebug to internationalize UI.
-     */
-    internationalizeUI: function(doc)
-    {
-        if (FBTrace.DBG_CONSOLEEXPORT)
-            FBTrace.sysout("consoleexport.internationalizeUI");
-
-        var elements = ["consoleExportAuto, consoleExportHelp, consoleExportAbout",
-            "consoleExportToFile", "consoleExportMenu"];
-
-        for (var i=0; i<elements.length; i++)
+    Firebug.ConsoleExport = extend(Firebug.Module,
+        /** @lends Firebug.ConsoleExport */
         {
-            var element = $(elements[i], doc);
-            if (!element)
-                continue;
+            /**
+             * Called by Firebug when new browser window is opened with Firebug.
+             */
+            initialize: function()
+            {
+                Firebug.Module.initialize.apply(this, arguments);
 
-            FBL.internationalize(element, "label");
-            FBL.internationalize(element, "tooltiptext");
-            FBL.internationalize(element, "buttontooltiptext");
-        }
-    },
+                if (Firebug.TraceModule)
+                    Firebug.TraceModule.addListener(this.TraceListener);
+            },
 
-    /**
-     * Initialize context (the object with per-page data). There are currently
-     * no data in the context, but this at least reserves the namespace.
-     */
-    initContext: function(context)
-    {
-        context.consoleExport = {};
-    },
+            /**
+             * Called by Firebug when a browser window with Firebug is closed.
+             */
+            shutdown: function()
+            {
+                Firebug.Module.shutdown.apply(this, arguments);
 
-    /**
-     * Toggle auto-export on and off. This method is called when the user clicks
-     * the toolbar button.
-     */
-    toggleAutoExport: function(context)
-    {
-        if (this.Automation.isActive())
-            this.Automation.deactivate();
-        else
-            this.Automation.activate();
-    },
+                if (Firebug.TraceModule)
+                    Firebug.TraceModule.removeListener(this.TraceListener);
+            },
 
-    /**
-     * Opens an online help page in a new tab.
-     * xxxHonza: the page doesn't exist yet.
-     */
-    onHelp: function(event)
-    {
-        openNewTab("http://www.janodvarko.cz/consoleexport/");
-        cancelEvent(event);
-    },
+            /**
+             * Called by Firebug to internationalize UI.
+             */
+            internationalizeUI: function(doc)
+            {
+                if (FBTrace.DBG_CONSOLEEXPORT)
+                    FBTrace.sysout("consoleexport.internationalizeUI");
 
-    /**
-     * Opens an online help page in a new tab.
-     * xxxHonza: the page doesn't exist yet.
-     */
-    onAbout: function(event, context)
-    {
-        Components.utils["import"]("resource://gre/modules/AddonManager.jsm");
+                var elements = ["consoleExportAuto, consoleExportHelp, consoleExportAbout",
+                    "consoleExportToFile", "consoleExportMenu"];
 
-        // Firefox 4.0 implements new AddonManager.
-        if (AddonManager)
-        {
-            AddonManager.getAddonByID("firebug@software.joehewitt.com", function(addon) {
-                openDialog("chrome://mozapps/content/extensions/about.xul", "",
-                "chrome,centerscreen,modal", addon);
-            });
-        }
-        else
-        {
-            var extensionManager = FBL.CCSV("@mozilla.org/extensions/manager;1",
-                "nsIExtensionManager");
+                for (var i=0; i<elements.length; i++)
+                {
+                    var element = $(elements[i], doc);
+                    if (!element)
+                        continue;
 
-            openDialog("chrome://mozapps/content/extensions/about.xul", "",
-                "chrome,centerscreen,modal", "urn:mozilla:item:consoleexport@janodvarko.cz",
-                extensionManager.datasource);
-        }
-    },
+                    FBL.internationalize(element, "label");
+                    FBL.internationalize(element, "tooltiptext");
+                    FBL.internationalize(element, "buttontooltiptext");
+                }
+            },
 
-    onSaveAs: function(event, context)
-    {
-        var file = this.getTargetFile(context);
-        if (!file)
-            return;
+            /**
+             * Initialize context (the object with per-page data). There are currently
+             * no data in the context, but this at least reserves the namespace.
+             */
+            initContext: function(context)
+            {
+                context.consoleExport = {};
+            },
 
-        var doc = context.getPanel("console").document;
-        var serializer = new XMLSerializer();
-        var foStream = Cc["@mozilla.org/network/file-output-stream;1"].createInstance(Ci.nsIFileOutputStream);
-        file.createUnique(Ci.nsIFile.NORMAL_FILE_TYPE, 0666);
-        foStream.init(file, 0x02 | 0x08 | 0x20, 0664, 0);   // write, create, truncate
-        serializer.serializeToStream(doc, foStream, "");   // remember, doc is the DOM tree
-        foStream.close();
-    },
+            /**
+             * Toggle auto-export on and off. This method is called when the user clicks
+             * the toolbar button.
+             */
+            toggleAutoExport: function(context)
+            {
+                if (this.Automation.isActive())
+                    this.Automation.deactivate();
+                else
+                    this.Automation.activate();
+            },
 
-    // Open File Save As dialog and let the user to pick proper file location.
-    getTargetFile: function(context)
-    {
-        var nsIFilePicker = Ci.nsIFilePicker;
-        var fp = CCIN("@mozilla.org/filepicker;1", "nsIFilePicker");
-        fp.init(window, null, nsIFilePicker.modeSave);
-        fp.appendFilters(nsIFilePicker.filterAll | nsIFilePicker.  filterHTML);
-        fp.filterIndex = 1;
+            /**
+             * Opens an online help page in a new tab.
+             * xxxHonza: the page doesn't exist yet.
+             */
+            onHelp: function(event)
+            {
+                openNewTab("http://www.janodvarko.cz/consoleexport/");
+                cancelEvent(event);
+            },
 
-        var defaultFileName = this.getDefaultFileName(context) + ".html";
+            /**
+             * Opens an online help page in a new tab.
+             * xxxHonza: the page doesn't exist yet.
+             */
+            onAbout: function(event, context)
+            {
+                Components.utils["import"]("resource://gre/modules/AddonManager.jsm");
 
-        fp.defaultString = defaultFileName;
+                // Firefox 4.0 implements new AddonManager.
+                if (AddonManager)
+                {
+                    AddonManager.getAddonByID("firebug@software.joehewitt.com", function(addon) {
+                        openDialog("chrome://mozapps/content/extensions/about.xul", "",
+                            "chrome,centerscreen,modal", addon);
+                    });
+                }
+                else
+                {
+                    var extensionManager = FBL.CCSV("@mozilla.org/extensions/manager;1",
+                        "nsIExtensionManager");
 
-        var rv = fp.show();
-        if (rv == nsIFilePicker.returnOK || rv == nsIFilePicker.returnReplace)
-            return fp.file;
+                    openDialog("chrome://mozapps/content/extensions/about.xul", "",
+                        "chrome,centerscreen,modal", "urn:mozilla:item:consoleexport@janodvarko.cz",
+                        extensionManager.datasource);
+                }
+            },
 
-        return null;
-    },
+            onSaveAs: function(event, context)
+            {
+                var file = this.getTargetFile(context);
+                if (!file)
+                    return;
 
-    getDefaultFileName: function(context)
-    {
-        var loc = Firebug.ConsoleExport.safeGetWindowLocation(context.window);
-        return  (loc & loc.host) ? loc.host : "firebug-console";
-    },
-});
+                var doc = context.getPanel("console").document;
+                var serializer = new XMLSerializer();
+                var foStream = Cc["@mozilla.org/network/file-output-stream;1"].createInstance(Ci.nsIFileOutputStream);
+                file.createUnique(Ci.nsIFile.NORMAL_FILE_TYPE, 0666);
+                foStream.init(file, 0x02 | 0x08 | 0x20, 0664, 0);   // write, create, truncate
+                serializer.serializeToStream(doc, foStream, "");   // remember, doc is the DOM tree
+                foStream.close();
+            },
+
+            // Open File Save As dialog and let the user to pick proper file location.
+            getTargetFile: function(context)
+            {
+                var nsIFilePicker = Ci.nsIFilePicker;
+                var fp = CCIN("@mozilla.org/filepicker;1", "nsIFilePicker");
+                fp.init(window, null, nsIFilePicker.modeSave);
+                fp.appendFilters(nsIFilePicker.filterAll | nsIFilePicker.  filterHTML);
+                fp.filterIndex = 1;
+
+                var defaultFileName = this.getDefaultFileName(context) + ".html";
+
+                fp.defaultString = defaultFileName;
+
+                var rv = fp.show();
+                if (rv == nsIFilePicker.returnOK || rv == nsIFilePicker.returnReplace)
+                    return fp.file;
+
+                return null;
+            },
+
+            getDefaultFileName: function(context)
+            {
+                var loc = Firebug.ConsoleExport.safeGetWindowLocation(context.window);
+                return  (loc & loc.host) ? loc.host : "firebug-console";
+            },
+        });
 
 // ************************************************************************************************
 // Shared functions
 
-Firebug.ConsoleExport.safeGetWindowLocation = function(win)
-{
-    try
+    Firebug.ConsoleExport.safeGetWindowLocation = function(win)
     {
-        if (!win)
-            return null;
-
-        if (win.closed)
-            return null;
-
-        if ("location" in win)
+        try
         {
-            if (typeof(win.location) == "object" && "toString" in win.location)
-                return win.location;
-            else if (typeof (win.location) == "string")
-                return win.location;
-        }
-    }
-    catch(exc)
-    {
-        if (FBTrace.DBG_NETEXPORT || FBTrace.DBG_ERRORS)
-            FBTrace.sysout("netexport.getWindowLocation; EXCEPTION window:", win);
-    }
+            if (!win)
+                return null;
 
-    return null;
-}
+            if (win.closed)
+                return null;
+
+            if ("location" in win)
+            {
+                if (typeof(win.location) == "object" && "toString" in win.location)
+                    return win.location;
+                else if (typeof (win.location) == "string")
+                    return win.location;
+            }
+        }
+        catch(exc)
+        {
+            if (FBTrace.DBG_NETEXPORT || FBTrace.DBG_ERRORS)
+                FBTrace.sysout("netexport.getWindowLocation; EXCEPTION window:", win);
+        }
+
+        return null;
+    }
 
 // ************************************************************************************************
 
-/**
- * Listener for Firebug tracing console (console for debugging Firebug and Firebug extensions)
- * This listener customizes appearance of ConsoleExport messages in the console so, they are
- * easily distinguishable from other messages.
- * This extension uses extensions.firebug.DBG_CONSOLEEXPORT preference, which creates new
- * CONSOLEEXPORT option in the Firebug tracing console.
- */
-Firebug.ConsoleExport.TraceListener =
-/** @lends Firebug.ConsoleExport.TraceListener */
-{
-    onLoadConsole: function(win, rootNode)
+    /**
+     * Listener for Firebug tracing console (console for debugging Firebug and Firebug extensions)
+     * This listener customizes appearance of ConsoleExport messages in the console so, they are
+     * easily distinguishable from other messages.
+     * This extension uses extensions.firebug.DBG_CONSOLEEXPORT preference, which creates new
+     * CONSOLEEXPORT option in the Firebug tracing console.
+     */
+    Firebug.ConsoleExport.TraceListener =
+    /** @lends Firebug.ConsoleExport.TraceListener */
     {
-        var doc = rootNode.ownerDocument;
-        var styleSheet = createStyleSheet(doc,
-            "chrome://consoleexport/skin/consoleexport.css");
-        styleSheet.setAttribute("id", "consoleExportLogs");
-        addStyleSheet(doc, styleSheet);
-    },
+        onLoadConsole: function(win, rootNode)
+        {
+            var doc = rootNode.ownerDocument;
+            var styleSheet = createStyleSheet(doc,
+                "chrome://consoleexport/skin/consoleexport.css");
+            styleSheet.setAttribute("id", "consoleExportLogs");
+            addStyleSheet(doc, styleSheet);
+        },
 
-    onDump: function(message)
-    {
-        var index = message.text.indexOf("consoleexport.");
-        if (index == 0)
-            message.type = "DBG_CONSOLEEXPORT";
-    }
-};
+        onDump: function(message)
+        {
+            var index = message.text.indexOf("consoleexport.");
+            if (index == 0)
+                message.type = "DBG_CONSOLEEXPORT";
+        }
+    };
 
 // ************************************************************************************************
 // Registration
 
-Firebug.registerStringBundle("chrome://consoleexport/locale/consoleexport.properties");
-Firebug.registerModule(Firebug.ConsoleExport);
+    Firebug.registerStringBundle("chrome://consoleexport/locale/consoleexport.properties");
+    Firebug.registerModule(Firebug.ConsoleExport);
 
 // ************************************************************************************************
 }});


### PR DESCRIPTION
1) print full console messages when string substitutions (%s,%d,..) are used.
2) print UTC date in output.
3) append console log messages once a log event is triggered (consoleDumper.js), opposed to current implementation which writes log upon 'shutdown' event. Seems that current implementation doesn't work properly (at least when used in automation with WebDriver). If needed I can create a separate pull request for this change specifically.