### PR TITLE
Added "dumpOnMessage" option and "text" log format

### DIFF
--- a/defaults/preferences/consoleexport.js
+++ b/defaults/preferences/consoleexport.js
@@ -3,3 +3,4 @@ pref("extensions.firebug.consoleexport.active", false);
 pref("extensions.firebug.consoleexport.serverURL", "");
 pref("extensions.firebug.consoleexport.format", "xml");
 pref("extensions.firebug.consoleexport.logFilePath", "");
+pref("extensions.firebug.consoleexport.dumpOnMessage", false);


### PR DESCRIPTION
Added an option to dump message when it's emitted (real time), useful if Firefox crashes and does not execute the shutdown function.

Added the "text" format, it's like the text showed on Firebug console.